### PR TITLE
Fix kill-emacs-query-function when auto-save is 0

### DIFF
--- a/persp-mode.el
+++ b/persp-mode.el
@@ -1150,9 +1150,11 @@ to a wrong one.")
          t)))))
 (defun persp-kill-emacs-h ()
   (persp-asave-on-exit nil))
+
 (defun persp-kill-emacs-query-function ()
-  (when (persp-asave-on-exit t)
-    (remove-hook 'kill-emacs-hook #'persp-kill-emacs-h)))
+  (if (persp-asave-on-exit t)
+      (remove-hook 'kill-emacs-hook #'persp-kill-emacs-h)
+    t))
 
 (defun persp-special-last-buffer-make-current ()
   (setq persp-special-last-buffer (current-buffer)))


### PR DESCRIPTION
When `persp-auto-save-opt` is 0, `persp-asave-on-exit` will return `nil`, which makes `persp-kill-emacs-query-function` return `nil`, which prevents `save-buffers-kill-emacs` from finishing, which means Emacs never exits (because `save-buffers-kill-emacs` runs `persp-kill-emacs-query-function` using `run-hook-with-args-until-failure`, and `nil` indicates a failure).