### PR TITLE
persp-copy: Fix adding buffers when not choosing

### DIFF
--- a/persp-mode.el
+++ b/persp-mode.el
@@ -2626,8 +2626,11 @@ cause it already contain all buffers.")))
               (copy-list (safe-persp-parameters current-persp))
               (persp-weak new-persp)
               (if current-persp (persp-weak current-persp) nil))
-        (when (listp choosen-buffers)
-          (persp-add-buffer choosen-buffers new-persp nil nil))
+        (let ((buffers (if (listp choosen-buffers)
+                           choosen-buffers
+                         new-buffers)))
+          (when buffers
+            (persp-add-buffer buffers new-persp nil nil)))
         (case switch
           (window (persp-window-switch new-name))
           (frame (persp-frame-switch new-name))


### PR DESCRIPTION
Fix `persp-copy` to add buffers to the new perspective even when the list of buffers is not interactively chosen.

Commit b476af23e15c3c04072f9816afb686184849e177 broke this logic.

* `persp-mode.el` (`persp-copy`): Add `new-buffers` to the perspective if `choosen-buffers` is not a list.