### PR TITLE
Pretty-print perspective state when saving to file

### DIFF
--- a/persp-mode.el
+++ b/persp-mode.el
@@ -3786,7 +3786,7 @@ of the perspective %s can't be saved."
              ";; -*- mode: emacs-lisp; eval: (progn (pp-buffer) (indent-buffer)) -*-")
             (newline)
             (insert (let (print-length print-level)
-                      (prin1-to-string (persps-to-savelist phash))))
+                      (pp-to-string (persps-to-savelist phash))))
             (persp-save-with-backups p-save-file)))))))
 
 (cl-defun persp-save-to-file-by-names


### PR DESCRIPTION
Although state file is pretty-printed on opening, this would write the files already pretty-printed.

This is helpful specially when troubleshooting by making easier to read the saved contents. It would even make unnecessary the `eval:` local variable.

Notice that calling `pp-to-string` already indents correctly.