### PR TITLE
Provide old name as initial input to interactive rename of perspective

### DIFF
--- a/persp-mode.el
+++ b/persp-mode.el
@@ -2868,7 +2868,7 @@ Return old name on success, otherwise nil."
         (unless new-name
           (setq new-name
                 (read-string
-                 (concat "New name for the " old-name " perspective: "))))
+                 (concat "New name for the " old-name " perspective: ") old-name)))
         (if (and (not (persp-p opersp)) new-name
                  (not (equal old-name new-name)))
             (progn


### PR DESCRIPTION
In case the rename is intended to result in only a slightly modified
version of the old name, it is convenient to edit it rather than type
it out all the way from scratch.

In case of a rename to a completely different name, it should be easy
enough to first kill the initial input with something like `C-a k` or
`M-backspace` before typing it out.

Fixes #127.