### PR TITLE
Fix lexical binding for funcall.

### DIFF
--- a/persp-mode.el
+++ b/persp-mode.el
@@ -1766,7 +1766,7 @@ the selected window to a wrong buffer.")
                            `(funcall (with-no-warnings ',load-function)
                                      savelist default-load-fun
                                      (with-no-warnings ',after-load-function))
-                         `(funcall default-load-fun savelist))))))
+                         `(funcall (eval default-load-fun t) savelist))))))
               append)))
 
 ;;;###autoload


### PR DESCRIPTION
Using `:after-load-function` in `persp-def-buffer-save/load` causes error `Symbol’s value as variable is void: persp-after-load-function`, as what happened in [this issue](https://github.com/doomemacs/doomemacs/issues/3558) (and doomemacs turned to `:load-function` to avoid this error).

This bug was introduced in af24502de46eb3b11d14761d2eff44ac7c024a38. In the function `perps-def-buffer-save/load`, the interpreter won't capture outside local variable `persp-after-load-function` for quoted expression `persp-after-load-lambda` in `add-hook`.

```lisp
(cl-defun persp-def-buffer-save/load (...)
  ;; ...
  (setq load-fun
        '(lambda (savelist)
            ;; ...
            (let ((persp-after-load-function (with-no-warnings
                                                    ',after-load-function))
                   persp-after-load-lambda)
              (setq persp-after-load-λ
                    #'(λ (...)
                         ;; `persp-after-load-function' cannot be captured here
                         (apply persp-after-load-function persp-loaded-buffer pall-args)
              ))
              (add-hook 'persp-after-load-state-functions persp-after-load-lambda t))))
    ;; ...
    (funcall load-fun ...))
```

So when the hook is triggered, the interpreter cannot find `persp-after-load-function`.

This is because Emacs Lisp won't capture outside local variables for quoted expressions (as data), even though `lexical-binding` was turned on globally. So I wrapped `default-load-fun` with `(eval ... t)`, in which the second argument means using lexical binding for evaluation.