### PR TITLE
Ensure current-buffer is up to date

### DIFF
--- a/persp-mode.el
+++ b/persp-mode.el
@@ -3054,7 +3054,8 @@ Return `NAME'."
              (unless (persp-contain-buffer-p cbuf persp)
                (persp-set-another-buffer-for-window cbuf frame-or-window persp)))
            (with-selected-window frame-or-window
-             (run-hook-with-args 'persp-activated-functions 'window))))))))
+             (run-hook-with-args 'persp-activated-functions 'window)))))))
+  (set-buffer (window-buffer (selected-window))))
 
 (defun persp-init-new-frame (frame)
   (condition-case-unless-debug err


### PR DESCRIPTION
Hi. Currently, after switching persps, the buffer before the switch is still set as `(current-buffer)`, so the `post-command-hook` is ran for that buffer with the new buffer as the `(window-buffer)`. This can cause untold horrors like in: https://github.com/magit/magit/pull/5098. And the Emacs maintainers have declared this behavior in a command to be a bug in:
https://debbugs.gnu.org/cgi/bugreport.cgi?bug=69259.